### PR TITLE
Support NextJS 13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "ast_node"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a614981a880a40522cf6fbe8b1a8365eb253655939f812a9db03e8ba4e2cb1f"
+checksum = "cf94863c5fdfee166d0907c44e5fee970123b2b7307046d35d1e671aa93afbba"
 dependencies = [
  "darling",
  "pmutil",
@@ -233,15 +233,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "debug_unreachable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a032eac705ca39214d169f83e3d3da290af06d8d1d344d1baad2fd002dca4b3"
-dependencies = [
- "unreachable",
 ]
 
 [[package]]
@@ -1213,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "string_enum"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f584cc881e9e5f1fd6bf827b0444aa94c30d8fe6378cf241071b5f5700b2871f"
+checksum = "994453cd270ad0265796eb24abf5540091ed03e681c5f3c12bc33e4db33253e1"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -1281,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "0.4.14"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1106fb9b9fde9bd37b9e36ecc05bc1fa9f8ace6f425391ff2ec1141e041e8bd2"
+checksum = "79642938ff437f2217718abf30a3450b014f600847c8f4bd60fa44f88a5210ea"
 dependencies = [
  "once_cell",
  "rkyv",
@@ -1296,9 +1287,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.28.3"
+version = "0.29.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f22d127a374f2a34d7e78e0bc4e20cbeaac8ee433bf8c774e61edb591ffd0a"
+checksum = "c649d1932fb68dd5b80837b8e12ef26f863a0dbf04ff9d137c9c8705451d8749"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1306,9 +1297,9 @@ dependencies = [
  "atty",
  "better_scoped_tls",
  "cfg-if",
- "debug_unreachable",
  "either",
  "from_variant",
+ "new_debug_unreachable",
  "num-bigint",
  "once_cell",
  "parking_lot",
@@ -1316,6 +1307,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "siphasher",
+ "sourcemap",
  "string_cache",
  "swc_atoms",
  "swc_eq_ignore_macros",
@@ -1328,9 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.23.13"
+version = "0.40.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b350bff1fc51c1073255d74799e68b283763e50b1c7cef9d0608cf8df5da28a"
+checksum = "ce749bfb28b8ef6653b83df20273ab3bc8ec5a3d99bc2745e59534702fc9e149"
 dependencies = [
  "once_cell",
  "swc_atoms",
@@ -1348,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.91.3"
+version = "0.94.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645ede33220fe9c3c35c8c7aa419d23fd4ae4a7e4834c020ba8101b3b32c71ed"
+checksum = "d7842ad1e129520d93860a49c74b12541700bb7830378af14718345134f94ecc"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -1366,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.124.8"
+version = "0.127.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee7b2f3b7f14c52cde042c2fb5e6b33179b192ec65a6e674fe46585afb3af363"
+checksum = "ee381cc50759f7a8e0d4fb45b39877673d669bd0a3cea5978940d8e94597ff6f"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -1398,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.119.7"
+version = "0.122.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b51311bd720103dce417b275d58032d6794e039efbf2a39c4d4b1d4b2d06dbb"
+checksum = "f48a1907ac2090d07ed414e2f9255565c5a8a973d2b4e5ff2f9b95592669bd39"
 dependencies = [
  "either",
  "enum_kind",
@@ -1417,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.30.7"
+version = "0.33.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5fc618da8e1e56fa13dd10d3343a5ff7b231afd113bc9adc5bbd35e20567080"
+checksum = "5bc452ac862cc85cb454161ac35de6fc78b029c17f5c895e616fa4b6378774be"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -1435,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.17.8"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb01a5e0a3eac52cb66e0f9b110ff699a17c3fc476a69fa87f5e792240804a82"
+checksum = "21ecc467eff7ef4ec0a64919402b94da637003015d019de4d649e8efeceafd3f"
 dependencies = [
  "anyhow",
  "hex",
@@ -1445,15 +1437,15 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_codegen",
  "testing",
+ "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.108.9"
+version = "0.111.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8152d04c02720401fac1551fb3f2ce0d95670c08cb6f13691856a2d6b5b277"
+checksum = "5c96aa73387314d84eca14c4580db4939155d3e525b724d8005271953ec4ca06"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -1473,16 +1465,18 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.110.9"
+version = "0.114.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b67d17afebb7c23b9583dfe945b3107355c3dcd220be6ed06dad0ee3371622"
+checksum = "81268585cfe7a8c563ab7b857bb99e792fd451bf82f978252d2f25919d630a39"
 dependencies = [
  "ansi_term",
  "anyhow",
+ "base64",
  "hex",
  "serde",
  "serde_json",
  "sha-1",
+ "sourcemap",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -1497,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.102.7"
+version = "0.105.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b19d69a87568ec2431106745b7c6930a1bdc3799cdf02526ae10f455d1b831d"
+checksum = "553e2437f78535ababf5e5872da53ee1781e53aae4985428d639819d2e5c5c38"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -1514,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.77.3"
+version = "0.80.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae3e2d13a22d8adaac9f38a5255431868da077da945ab2167720ad1fd091f31"
+checksum = "0c1cbe7df7a3dd724457f89b727bebaa4bca959d01ff9cf52f6fc33578693473"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -1540,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.12.3"
+version = "0.13.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c921ba5177047723b2ecc6ac2b2fd78cc9a0d59472c6c3ceef5f041fb05b9cd6"
+checksum = "ca8247e973d0b828ff0bcd4ea12ba94a8b240d7cc1840ad4b6286a1cc6009c02"
 dependencies = [
  "anyhow",
  "miette",
@@ -1585,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.19.4"
+version = "0.22.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825008adbaf1115d90a661d65a97ef24dbec0ecbc4561ac5e536ee564882537"
+checksum = "21738ef08398f5ceb05fb458f6a11e018d889288049021aa65a9b8162f6339b5"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -1610,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b754ef01f2614eb469fd5215789bfd319566a3bf1033056d7a7bfb5a3c9a69f5"
+checksum = "82f2bcb7223e185c4c7cbf5e0c1207dec6d2bfd5e72e3fb7b3e8d179747e9130"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -1620,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c230bcd129d1fbcd1decd8b43cccd613fda11c895f7c04d6c966231dbc1959af"
+checksum = "8fb1f3561674d84947694d41fb6d5737d19539222779baeac1b3a071a2b29428"
 dependencies = [
  "Inflector",
  "pmutil",
@@ -1678,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.30.3"
+version = "0.31.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4709c3ab96e6840b3d7119cc9c11a599bd55c5d28850634db3f797cd681ab5b"
+checksum = "e23cc25b24484e7adecb8c660d71c9129a8d4ac7a5b3717ee8f43634616f66a4"
 dependencies = [
  "ansi_term",
  "difference",
@@ -1905,15 +1899,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "unreachable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
-dependencies = [
- "void",
-]
-
-[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1950,12 +1935,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swc-plugin-vanilla-extract",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "./target/wasm32-wasi/release/swc_plugin_vanilla_extract.wasm",
   "napi": {

--- a/packages/swc-plugin-vanilla-extract/Cargo.toml
+++ b/packages/swc-plugin-vanilla-extract/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["cdylib"]
 serde = "1"
 serde_json = "1"
 swc-vanilla-extract-visitor = { path = "../swc-vanilla-extract-visitor", version = "0.0.1" }
-swc_core                = { version = "0.23.13", features = ["plugin_transform", "ecma_visit_path"] }
+swc_core                = { version = "0.40.26", features = ["plugin_transform", "ecma_visit_path"] }

--- a/packages/swc-vanilla-extract-visitor/Cargo.toml
+++ b/packages/swc-vanilla-extract-visitor/Cargo.toml
@@ -11,7 +11,7 @@ version     = "0.0.1"
 once_cell = "1.14.0"
 regex          = "1.6.0"
 path-slash = "0.2.1"
-swc_core                = { version = "0.23.13", features = ["common", "ecma_quote", "ecma_ast", "ecma_visit", "ecma_visit_path"] }
+swc_core                = { version = "0.40.26", features = ["common", "ecma_quote", "ecma_ast", "ecma_visit", "ecma_visit_path"] }
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/packages/swc-vanilla-extract-visitor/src/lib.rs
+++ b/packages/swc-vanilla-extract-visitor/src/lib.rs
@@ -104,7 +104,7 @@ impl VisitMut for VanillaExtractVisitor {
                     span: DUMMY_SP,
                     local: FILE_SCOPE_IMPORT_NAME.clone(),
                 })],
-                src: Str::from(FILE_SCOPE_PACKAGE_IDENTIFIER),
+                src: Box::new(Str::from(FILE_SCOPE_PACKAGE_IDENTIFIER)),
                 type_only: false,
                 asserts: None,
             }));

--- a/spec/swc-vanilla-custom-transform/Cargo.toml
+++ b/spec/swc-vanilla-custom-transform/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.144", features = ["derive"] }
 serde_json = { version = "1.0.85", features = ["unbounded_depth"] }
 
 swc-vanilla-extract-visitor = { path = "../../packages/swc-vanilla-extract-visitor" }
-swc_core = { version = "0.23.13", features = [
+swc_core = { version = "0.40.26", features = [
   "common_concurrent",
   "ecma_transforms",
   "ecma_ast",


### PR DESCRIPTION
After updating to nextjs v13, I get the following error:

```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: LayoutError', /Users/ojkwon/.cargo/registry/src/github.com-1ecc6299db9ec823/rkyv-0.7.37/src/impls/core/mod.rs:265:67
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread '<unnamed>' panicked at 'failed to invoke plugin: failed to invoke plugin on 'Some("/.pnpm/next@13.0.0_qtpcxnaaarbm4ws7ughq6oxfve/node_modules/next/dist/client/dev/amp-dev.js")'

Caused by:
    0: failed to invoke `/.pnpm/swc-plugin-vanilla-extract@0.0.1/node_modules/swc-plugin-vanilla-extract/target/wasm32-wasi/release/swc_plugin_vanilla_extract.wasm` as js transform plugin at /.pnpm/swc-plugin-vanilla-extract@0.0.1/node_modules/swc-plugin-vanilla-extract/target/wasm32-wasi/release/swc_plugin_vanilla_extract.wasm
    1: RuntimeError: unreachable
           at rust_panic (<module>[683]:0x75907)
           at std::panicking::rust_panic_with_hook::h5af4a166307aff48 (<module>[240]:0x154a5)
           at std::panicking::begin_panic_handler::{{closure}}::h42a9871ead2de5e8 (<module>[689]:0x75dc7)
           at std::sys_common::backtrace::__rust_end_short_backtrace::h42a6bde96d4a4a1f (<module>[688]:0x75d12)
           at rust_begin_unwind (<module>[165]:0xf13d)
           at core::panicking::panic_fmt::h33d7d4c3033d60da (<module>[131]:0xcb2a)
           at core::result::unwrap_failed::h5d36bed23403009b (<module>[42]:0x5b82)
           at rkyv::impls::core::<impl rkyv::DeserializeUnsized<[U],D> for [T]>::deserialize_unsized::haba020d3ba44b626 (<module>[974]:0xc47ea)
           at __transform_plugin_process_impl (<module>[1312]:0x125bab)
           at __transform_plugin_process_impl.command_export (<module>[1739]:0x1aa942)
    2: unreachable', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/swc-0.232.53/src/plugin.rs:228:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread '<unnamed>thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: LayoutError', /Users/ojkwon/.cargo/registry/src/github.com-1ecc6299db9ec823/rkyv-0.7.37/src/impls/core/mod.rs:265:67
```

Was able to fix the error by bumping `swc_core` to the newest version.